### PR TITLE
Sticky header for refinement lists

### DIFF
--- a/frontend/src/algolia.css
+++ b/frontend/src/algolia.css
@@ -252,6 +252,8 @@
 
   .ais-Panel-header {
     @apply mb-2 text-xs font-bold uppercase;
+    @apply sticky top-0 bg-gray-50;
+  }
   }
 
   .ais-Panel-footer {

--- a/frontend/src/algolia.css
+++ b/frontend/src/algolia.css
@@ -254,7 +254,6 @@
     @apply mb-2 text-xs font-bold uppercase;
     @apply sticky top-0 bg-gray-50;
   }
-  }
 
   .ais-Panel-footer {
     @apply mt-2 text-xs;


### PR DESCRIPTION
Updated algolia.css in order to implement sticky-header upon scrolling.
.ais-Panel-header {
    @apply mb-2 text-xs font-bold uppercase;
    @apply sticky top-0 bg-gray-50;
  }