### PR TITLE
Update `caniuse-lite`

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -320,12 +320,6 @@
             "picocolors": "^1.0.0"
           }
         },
-        "caniuse-lite": {
-          "version": "1.0.30001303",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001303.tgz",
-          "integrity": "sha512-/Mqc1oESndUNszJP0kx0UaQU9kEv9nNtJ7Kn8AdA0mNnH8eR1cj0kG+NbNuC1Wq/b21eA8prhKRA3bbkjONegQ==",
-          "dev": true
-        },
         "electron-to-chromium": {
           "version": "1.4.57",
           "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.57.tgz",
@@ -2185,12 +2179,6 @@
             "picocolors": "^1.0.0"
           }
         },
-        "caniuse-lite": {
-          "version": "1.0.30001306",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001306.tgz",
-          "integrity": "sha512-Wd1OuggRzg1rbnM5hv1wXs2VkxJH/AA+LuudlIqvZiCvivF+wJJe2mgBZC8gPMgI7D76PP5CTx8Luvaqc1V6OQ==",
-          "dev": true
-        },
         "electron-to-chromium": {
           "version": "1.4.63",
           "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.63.tgz",
@@ -2479,9 +2467,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001249",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001249.tgz",
-      "integrity": "sha512-vcX4U8lwVXPdqzPWi6cAJ3FnQaqXbBqy/GZseKNQzRj37J7qZdGcBtxq/QLFNLLlfsoXLUdHw8Iwenri86Tagw==",
+      "version": "1.0.30001309",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001309.tgz",
+      "integrity": "sha512-Pl8vfigmBXXq+/yUz1jUwULeq9xhMJznzdc/xwl4WclDAuebcTHVefpz8lE/bMI+UN7TOkSSe7B7RnZd6+dzjA==",
       "dev": true
     },
     "chalk": {
@@ -6362,12 +6350,6 @@
             "node-releases": "^2.0.1",
             "picocolors": "^1.0.0"
           }
-        },
-        "caniuse-lite": {
-          "version": "1.0.30001306",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001306.tgz",
-          "integrity": "sha512-Wd1OuggRzg1rbnM5hv1wXs2VkxJH/AA+LuudlIqvZiCvivF+wJJe2mgBZC8gPMgI7D76PP5CTx8Luvaqc1V6OQ==",
-          "dev": true
         },
         "electron-to-chromium": {
           "version": "1.4.63",


### PR DESCRIPTION
Target browser changes:

```diff
- and_chr 92
+ and_chr 97
- and_ff 90
+ and_ff 96
- chrome 92
- chrome 91
- chrome 90
- chrome 89
- chrome 87
- chrome 85
+ chrome 97
+ chrome 96
+ chrome 95
+ chrome 94
+ chrome 93
- edge 92
- edge 91
+ edge 97
+ edge 96
- firefox 90
- firefox 89
+ firefox 96
+ firefox 95
- ios_saf 14.5-14.7
+ ios_saf 15.2-15.3
+ ios_saf 15.0-15.1
+ ios_saf 14.5-14.8
+ ios_saf 12.2-12.5
- opera 77
+ opera 82
+ safari 15.2-15.3
+ safari 15.1
+ safari 15
- samsung 14.0
- samsung 13.0
+ samsung 16.0
```

Currently supported browsers:

```
and_chr 97
and_ff 96
and_uc 12.12
android 4.4.3-4.4.4
chrome 97
chrome 96
chrome 95
chrome 94
chrome 93
edge 97
edge 96
firefox 96
firefox 95
ios_saf 15.2-15.3
ios_saf 15.0-15.1
ios_saf 14.5-14.8
ios_saf 14.0-14.4
ios_saf 13.4-13.7
ios_saf 12.2-12.5
opera 82
safari 15.2-15.3
safari 15.1
safari 15
safari 14.1
safari 14
safari 13.1
samsung 16.0
```