### PR TITLE
Cache Directus responses in development

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -17,3 +17,6 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+# Eleventy Fetch's cache: https://www.11ty.dev/docs/plugins/fetch/#cache-directory
+.cache

--- a/frontend/config/directus.js
+++ b/frontend/config/directus.js
@@ -3,8 +3,28 @@
  */
 
 const { createDirectus, staticToken, rest } = require('@directus/sdk');
+const EleventyFetch = require('@11ty/eleventy-fetch');
+
+const cachedFetch =
+  /**
+   * @type {import('@directus/sdk').FetchInterface}
+   * @param {RequestInit} init
+   */
+  (input, init) =>
+    // Caching only GET requests. See https://github.com/11ty/eleventy-fetch/issues/20
+    init.method === 'GET'
+      ? EleventyFetch(input, {
+          // Using such a small duration to catch up with changes in the CMS during development.
+          // Still, caching can help working offline: https://www.11ty.dev/docs/plugins/fetch/#what-happens-when-a-request-fails
+          duration: '1m',
+          // We suppose that all Directus requests return JSON
+          type: 'json',
+          // Not a well-documented option, see https://www.11ty.dev/docs/plugins/fetch/#fetch-google-fonts-css
+          fetchOptions: init,
+        })
+      : fetch(input, init);
 
 module.exports.getDirectusClient = () =>
-  createDirectus(process.env.DIRECTUS_URL)
+  createDirectus(process.env.DIRECTUS_URL, { globals: { fetch: cachedFetch } })
     .with(staticToken(process.env.DIRECTUS_STATIC_TOKEN))
     .with(rest());

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -15,6 +15,7 @@
       },
       "devDependencies": {
         "@11ty/eleventy": "2.0.1",
+        "@11ty/eleventy-fetch": "4.0.0",
         "@11ty/eleventy-navigation": "0.3.5",
         "@11ty/eleventy-plugin-vite": "PureBhaktiArchive/eleventy-plugin-vite#patched",
         "@directus/sdk": "14.0.0",
@@ -128,6 +129,25 @@
       },
       "bin": {
         "eleventy-dev-server": "cmd.js"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/11ty"
+      }
+    },
+    "node_modules/@11ty/eleventy-fetch": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@11ty/eleventy-fetch/-/eleventy-fetch-4.0.0.tgz",
+      "integrity": "sha512-wGAd0r+8DUWr22fK5r07dOKuNY6ltA7hX+sJzngGZL1yJmuUVdM/xPQZ+iq0BFgf/ZeRdpVEzf2D0cpVZUuiTg==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.3.4",
+        "flat-cache": "^3.0.4",
+        "node-fetch": "^2.6.7",
+        "p-queue": "^6.6.2"
       },
       "engines": {
         "node": ">=14"
@@ -5053,6 +5073,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "dev": true
+    },
     "node_modules/execa": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -7975,6 +8001,15 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -8003,6 +8038,34 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-queue": {
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.6.2.tgz",
+      "integrity": "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==",
+      "dev": true,
+      "dependencies": {
+        "eventemitter3": "^4.0.4",
+        "p-timeout": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-timeout": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
+      "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
+      "dev": true,
+      "dependencies": {
+        "p-finally": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/p-try": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,6 +15,7 @@
   },
   "devDependencies": {
     "@11ty/eleventy": "2.0.1",
+    "@11ty/eleventy-fetch": "4.0.0",
     "@11ty/eleventy-navigation": "0.3.5",
     "@11ty/eleventy-plugin-vite": "PureBhaktiArchive/eleventy-plugin-vite#patched",
     "@directus/sdk": "14.0.0",

--- a/frontend/src/_data/audios.js
+++ b/frontend/src/_data/audios.js
@@ -14,7 +14,8 @@ module.exports = ({ directus }) =>
       filter: { status: { _eq: 'active' } },
       // Fetching all items. Later, when number of records grows, we may need to fetch in pages as described in https://docs.directus.io/reference/query.html#offset
       // Also, we assume that the `QUERY_LIMIT_MAX` env variable is not set on the server.
-      limit: -1,
+      // Fetching only few items in the development mode to speed up rebuilding the pages
+      limit: process.env.ELEVENTY_RUN_MODE === 'build' ? -1 : 50,
       // Historically, in the code we refer to the `id` as `fileId`. Therefore using aliases here.
       alias: { fileId: 'id' },
     })


### PR DESCRIPTION
Required after #427 because there are many audio items, due to which the development process slows down.