### PR TITLE
Disable eslint warnings on Alpine

### DIFF
--- a/frontend/src/js/audio.js
+++ b/frontend/src/js/audio.js
@@ -2,6 +2,7 @@
  * sri sri guru gaurangau jayatah
  */
 
+// eslint-disable-next-line import/no-named-as-default -- See https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/69404
 import Alpine from 'alpinejs';
 import './player';
 import './webshare';

--- a/frontend/src/js/audios.js
+++ b/frontend/src/js/audios.js
@@ -3,6 +3,7 @@
  */
 
 import algoliasearch from 'algoliasearch/lite';
+// eslint-disable-next-line import/no-named-as-default -- See https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/69404
 import Alpine from 'alpinejs';
 import instantsearch from 'instantsearch.js/es';
 import {

--- a/frontend/src/js/common.js
+++ b/frontend/src/js/common.js
@@ -2,6 +2,7 @@
  * sri sri guru gaurangau jayatah
  */
 
+// eslint-disable-next-line import/no-named-as-default -- See https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/69404
 import Alpine from 'alpinejs';
 
 Alpine.start();

--- a/frontend/src/js/memories.js
+++ b/frontend/src/js/memories.js
@@ -3,6 +3,7 @@
  */
 
 import algoliasearch from 'algoliasearch/lite';
+// eslint-disable-next-line import/no-named-as-default -- See https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/69404
 import Alpine from 'alpinejs';
 import instantsearch from 'instantsearch.js/es';
 import {

--- a/frontend/src/js/player.js
+++ b/frontend/src/js/player.js
@@ -2,6 +2,7 @@
  * sri sri guru gaurangau jayatah
  */
 
+// eslint-disable-next-line import/no-named-as-default -- See https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/69404
 import Alpine from 'alpinejs';
 import { formatDurationForHumans } from './duration';
 

--- a/frontend/src/js/search-result-item.js
+++ b/frontend/src/js/search-result-item.js
@@ -2,6 +2,7 @@
  * sri sri guru gaurangau jayatah
  */
 
+// eslint-disable-next-line import/no-named-as-default -- See https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/69404
 import Alpine from 'alpinejs';
 
 /**

--- a/frontend/src/js/webshare.js
+++ b/frontend/src/js/webshare.js
@@ -2,6 +2,7 @@
  * sri sri guru gaurangau jayatah
  */
 
+// eslint-disable-next-line import/no-named-as-default -- See https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/69404
 import Alpine from 'alpinejs';
 import tippy from 'tippy.js';
 import 'tippy.js/dist/tippy.css';


### PR DESCRIPTION
As a temporary measure after updating Alpine to v3.13.4 in #455 due to https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/69404.